### PR TITLE
Actually become python 2 and 3 compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-stretch
+FROM python:2.7-buster
 RUN pip install tox
 WORKDIR /opt/macadamia
 COPY tox.ini .

--- a/macadamia/__init__.py
+++ b/macadamia/__init__.py
@@ -1,8 +1,8 @@
 import datetime
 try:
-    import urllib2 as url_library
+    from urllib2 import unquote
 except ImportError:
-    import urllib as url_library
+    from urllib.parse import unquote
 
 def parse_campaign_data(data):
     human_names = {
@@ -14,7 +14,7 @@ def parse_campaign_data(data):
       "utmgclid": "google_click_id",
     }
     fields = [d.split("=") for d in data.split("|")]
-    info = dict((human_names[d[0]] ,url_library.unquote(d[1])) for d in fields)
+    info = dict((human_names[d[0]], unquote(d[1])) for d in fields)
 
     return info
 

--- a/tests/test_utmz.py
+++ b/tests/test_utmz.py
@@ -5,7 +5,7 @@ from macadamia import parse_utmz
 @pytest.mark.parametrize(("cookie", "expected"),[
     ("44858868.462535200.44.2.utmcsr=localhost:9000|utmccn=(referral)|utmcmd=referral|utmcct=/", {
         "domain_hash": "44858868",
-        "timestamp": datetime.datetime(year=1984, month=8, day=28),
+        "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
         "session_counter": "44",
         "campaign_number": "2",
         "campaign_data": {
@@ -19,7 +19,7 @@ from macadamia import parse_utmz
         'campaign_number': '1',
         'domain_hash': '208940939',
         'session_counter': '1',
-        'timestamp': datetime.datetime(2013, 4, 5, 8, 33, 4),
+        'timestamp': datetime.datetime(2013, 4, 5, 18, 33, 4),
         'campaign_data': {
             'campaign_name': '(direct)',
             'medium': '(none)',
@@ -30,7 +30,7 @@ from macadamia import parse_utmz
         'campaign_number': '1',
         'domain_hash': '48016369',
         'session_counter': '1',
-        "timestamp": datetime.datetime(year=1984, month=8, day=28),
+        "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
         'campaign_data': {
             'campaign_content': '/clients/lee-cunningham/',
             'campaign_name': '(referral)',
@@ -42,7 +42,7 @@ from macadamia import parse_utmz
         'campaign_number': '3',
         'domain_hash': '44858868',
         'session_counter': '71',
-        "timestamp": datetime.datetime(year=1984, month=8, day=28),
+        "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
         'campaign_data': {
             'campaign_keyword': 'hawaii real estate',
             'campaign_name': '(organic)',
@@ -54,7 +54,7 @@ from macadamia import parse_utmz
         'campaign_number': '1',
         'domain_hash': '112962326',
         'session_counter': '1',
-        "timestamp": datetime.datetime(year=1984, month=8, day=28),
+        "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
         'campaign_data': {
             'campaign_keyword': 'real estate for sale in wilmington nc',
             'campaign_name': '(not set)',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py27, py35
+envlist = py27, py37
 toxworkdir={toxinidir}/../.tox
 
 [testenv]
 deps = 
     pytest
 commands =
-    python tests/test_utmz.py
+    pytest tests/test_utmz.py


### PR DESCRIPTION
Turns out our first pass at running the tests via tox
would **load** the tests but not actually run them.  So
we had fixed the import error but in execution it still
broke in python 3.

Here we upgraded the Dockerfile and tox to use python 3.7
and got the test passing.