### PR TITLE
Add support for new generic cookie parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    working_directory: /opt/app
+    docker:
+      - image: docker:20.10.18-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --update --no-cache \
+              docker-compose \
+              make
+      - run:
+          name: Build image
+          command: |
+            docker-compose build
+      - run:
+          name: Run tests
+          command: |
+            make test-circle

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APP=docker-compose run --rm app
+TOX=tox
 
 update:
 	docker-compose build
@@ -7,4 +8,7 @@ update:
 	docker-compose build
 
 test:
-	$(APP) tox
+	$(APP) $(TOX)
+
+test-circle:	# run automated tests like circle-ci would
+	docker-compose run --rm test-circle $(TOX)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+APP=docker-compose run --rm app
+
+update:
+	docker-compose build
+	docker-compose stop
+	docker-compose rm -f
+	docker-compose build
+
+test:
+	$(APP) tox

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ pip install macadamia
 {'domain_hash': '208940939', 'campaign_number': '1', 'campaign_data': {'source': '(direct)', 'campaign_name': '(direct)', 'medium': '(none)'}, 'timestamp': datetime.datetime(2013, 4, 5, 8, 33, 4), 'session_counter': '1'}
 ```
 
+```python
+>>> from macadamia import parse_cookie
+>>> cookie_to_parse = "208940939.1365186784.1.1.fiztmcsr=(direct)|fiztmccn=(direct)|fiztmcmd=(none)"
+>>> parsed_cookie = parse_cookie(cookie_to_parse, prefix="fiztm")
+>>> {'domain_hash': '208940939', 'campaign_number': '1', 'campaign_data': {'source': '(direct)', 'campaign_name': '(direct)', 'medium': '(none)'}, 'timestamp': datetime.datetime(2013, 4, 5, 8, 33, 4), 'session_counter': '1'}
+```
 
 ###__utma Visitor Cookie (lasts 2 years)
 Used to distinguish users and sessions. The cookie is created when the javascript library executes and no existing __utma cookies exists. The cookie is updated every time data is sent to Google Analytics.
@@ -102,6 +108,7 @@ make test
 
 ## Changelog
 
+* 0.1.0: Support cookies shaped like `_utmz` but with a different name
 * 0.0.7: Actually add Python 3 compatibility and upgrade Dockerfile base image to test against Python 3.7
 * 0.0.6: Python 3 compatibility and add Dockerfile for development
 * 0.0.5: Fix typo parsing `utmgclid` cookie value

--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ Sources:
 
 ## Running tests via tox and docker
 ```bash
-docker build -t macadamia . && docker run -ti -v `pwd`:/opt/macadamia macadamia bash
-# then within the docker container run tox
-tox
+make test
 ```
 
 ## Changelog

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,10 @@
 version: "3.9"
 
 services:
-  app:
+  app: &app-base
     build: .
     volumes:
       - .:/opt/macadamia
+  test-circle:
+    <<: *app-base
+    volumes: []

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/opt/macadamia

--- a/macadamia/__init__.py
+++ b/macadamia/__init__.py
@@ -1,29 +1,40 @@
 import datetime
+
 try:
     from urllib2 import unquote
 except ImportError:
     from urllib.parse import unquote
 
-def parse_campaign_data(data):
+
+def parse_campaign_data(data, prefix="utm"):
     human_names = {
-      "utmcsr": "source",
-      "utmcmd": "medium",
-      "utmccn": "campaign_name",
-      "utmctr": "campaign_keyword",
-      "utmcct": "campaign_content",
-      "utmgclid": "google_click_id",
+        "%scsr" % prefix: "source",
+        "%scmd" % prefix: "medium",
+        "%sccn" % prefix: "campaign_name",
+        "%sctr" % prefix: "campaign_keyword",
+        "%scct" % prefix: "campaign_content",
+        "%sgclid" % prefix: "google_click_id",
     }
+
     fields = [d.split("=") for d in data.split("|")]
     info = dict((human_names[d[0]], unquote(d[1])) for d in fields)
 
     return info
 
-def parse_utmz(cookie):
-    fields = cookie.split('.')
+
+def parse_cookie(cookie, prefix="utm"):
+    fields = cookie.split(".")
+
+    campaign_data = parse_campaign_data(".".join(fields[4:]), prefix=prefix)
+
     return {
         "domain_hash": fields[0],
         "timestamp": datetime.datetime.fromtimestamp(int(fields[1])),
         "session_counter": fields[2],
         "campaign_number": fields[3],
-        "campaign_data": parse_campaign_data(".".join(fields[4:])),
+        "campaign_data": campaign_data,
     }
+
+
+def parse_utmz(cookie):
+    return parse_cookie(cookie, prefix="utm")

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 setup(name='macadamia',
-      version='0.0.7',
+      version='0.1.0',
       description="A parser for Google Analytics Cookies",
       author='Kevin McCarthy',
       author_email='me@kevinmccarthy.org',

--- a/tests/test_fiztmz.py
+++ b/tests/test_fiztmz.py
@@ -1,0 +1,87 @@
+import datetime
+import pytest
+from macadamia import parse_cookie
+
+
+@pytest.mark.parametrize(
+    ("cookie", "expected"),
+    [
+        (
+            "44858868.462535200.44.2.fiztmcsr=localhost:9000|fiztmccn=(referral)|fiztmcmd=referral|fiztmcct=/",
+            {
+                "domain_hash": "44858868",
+                "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
+                "session_counter": "44",
+                "campaign_number": "2",
+                "campaign_data": {
+                    "campaign_content": "/",
+                    "campaign_name": "(referral)",
+                    "medium": "referral",
+                    "source": "localhost:9000",
+                },
+            },
+        ),
+        (
+            "208940939.1365186784.1.1.fiztmcsr=(direct)|fiztmccn=(direct)|fiztmcmd=(none)",
+            {
+                "campaign_number": "1",
+                "domain_hash": "208940939",
+                "session_counter": "1",
+                "timestamp": datetime.datetime(2013, 4, 5, 18, 33, 4),
+                "campaign_data": {
+                    "campaign_name": "(direct)",
+                    "medium": "(none)",
+                    "source": "(direct)",
+                },
+            },
+        ),
+        (
+            "48016369.462535200.1.1.fiztmcsr=realgeeks.com|fiztmccn=(referral)|fiztmcmd=referral|fiztmcct=/clients/lee-cunningham/",
+            {
+                "campaign_number": "1",
+                "domain_hash": "48016369",
+                "session_counter": "1",
+                "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
+                "campaign_data": {
+                    "campaign_content": "/clients/lee-cunningham/",
+                    "campaign_name": "(referral)",
+                    "medium": "referral",
+                    "source": "realgeeks.com",
+                },
+            },
+        ),
+        (
+            "44858868.462535200.71.3.fiztmcsr=google|fiztmccn=(organic)|fiztmcmd=organic|fiztmctr=hawaii%20real%20estate",
+            {
+                "campaign_number": "3",
+                "domain_hash": "44858868",
+                "session_counter": "71",
+                "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
+                "campaign_data": {
+                    "campaign_keyword": "hawaii real estate",
+                    "campaign_name": "(organic)",
+                    "medium": "organic",
+                    "source": "google",
+                },
+            },
+        ),
+        (
+            "112962326.462535200.1.1.fiztmgclid=CMbMrdi_ybgCFWho7AodDyAAvQ|fiztmccn=(not set)|fiztmcmd=(not set)|fiztmctr=real estate for sale in wilmington nc",
+            {
+                "campaign_number": "1",
+                "domain_hash": "112962326",
+                "session_counter": "1",
+                "timestamp": datetime.datetime(year=1984, month=8, day=28, hour=10),
+                "campaign_data": {
+                    "campaign_keyword": "real estate for sale in wilmington nc",
+                    "campaign_name": "(not set)",
+                    "google_click_id": "CMbMrdi_ybgCFWho7AodDyAAvQ",
+                    "medium": "(not set)",
+                },
+            },
+        ),
+    ],
+)
+def test_cookie_split_and_parse(cookie, expected):
+    info = parse_cookie(cookie, prefix="fiztm")
+    assert info == expected

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = py27, py37
 toxworkdir={toxinidir}/../.tox
 
 [testenv]
-deps = 
+deps =
     pytest
 commands =
     pytest tests/test_utmz.py
+    pytest tests/test_fiztmz.py


### PR DESCRIPTION
The `_utmz` cookie is deprecated and no longer set by the Google Tag (gtag.js). In order to support replacing the `_utmz` cookie with your own version with a different name and keys this PR allows for parsing cookies that use a substitute for `utm`. For example, you could create the `fiztmz` cookie and pass the `fizt` prefix.
